### PR TITLE
Remove User ID from Path Variables

### DIFF
--- a/src/main/java/com/skillstorm/transactionservice/controllers/TransactionController.java
+++ b/src/main/java/com/skillstorm/transactionservice/controllers/TransactionController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@CrossOrigin
 @RequestMapping("/transactions")
 public class TransactionController {
 
@@ -23,33 +22,46 @@ public class TransactionController {
     }
 
     // Mapping for getting all transactions by userId
-    @GetMapping("/user/{userId}")
-    public ResponseEntity<List<Transaction>> getTransactionsByUserId(@PathVariable int userId, @RequestHeader HttpHeaders headers) {
-        transactionService.validateUserId(userId, headers);
+    @GetMapping
+    public ResponseEntity<List<Transaction>> getTransactionsByUserId(@RequestHeader HttpHeaders headers) {
+        transactionService.validateRequestWithHeaders(headers);
+
+        // the validation function should catch any errors by this point, so this is safe
+        int userId = Integer.parseInt(headers.getFirst("User-ID"));
+
         List<Transaction> transactionsList = transactionService.getTransactionsByUserId(userId);
         return new ResponseEntity<>(transactionsList, HttpStatus.OK);
     }
 
-    //Mapping for getting most recent 5 transactions
-    @GetMapping("/recentTransactions/{userId}")
-    public ResponseEntity<List<Transaction>> getRecentFiveTransactions(@PathVariable int userId, @RequestHeader HttpHeaders headers){
-        transactionService.validateUserId(userId, headers);
+    // Mapping for getting most recent 5 transactions
+    @GetMapping("/recentTransactions")
+    public ResponseEntity<List<Transaction>> getRecentFiveTransactions(@RequestHeader HttpHeaders headers) {
+        transactionService.validateRequestWithHeaders(headers);
+
+        int userId = Integer.parseInt(headers.getFirst("User-ID"));
+
         List<Transaction> transactionsList = transactionService.getRecentFiveTransactions(userId);
         return new ResponseEntity<>(transactionsList, HttpStatus.OK);
     }
 
-    //Mapping for getting transaction for the current month
-    @GetMapping("/currentMonthTransactions/{userId}")
-    public ResponseEntity<List<Transaction>> getTransactionsFromCurrentMonth(@PathVariable int userId, @RequestHeader HttpHeaders headers){
-        transactionService.validateUserId(userId, headers);
+    // Mapping for getting transaction for the current month
+    @GetMapping("/currentMonthTransactions")
+    public ResponseEntity<List<Transaction>> getTransactionsFromCurrentMonth(@RequestHeader HttpHeaders headers) {
+        transactionService.validateRequestWithHeaders(headers);
+
+        int userId = Integer.parseInt(headers.getFirst("User-ID"));
+
         List<Transaction> transactionsList = transactionService.getTransactionsFromCurrentMonth(userId);
         return new ResponseEntity<>(transactionsList, HttpStatus.OK);
     }
 
-    //Mapping for getting all transactions by vendorName and userId
-    @GetMapping("/user/{userId}/vendor/{vendorName}")
-    public ResponseEntity<List<Transaction>> getTransactionsByUserIdAndVendorName(@PathVariable int userId, @PathVariable String vendorName, @RequestHeader HttpHeaders headers) {
-        transactionService.validateUserId(userId, headers);
+    // Mapping for getting all transactions by vendorName and userId
+    @GetMapping("/vendor/{vendorName}")
+    public ResponseEntity<List<Transaction>> getTransactionsByUserIdAndVendorName(@PathVariable String vendorName, @RequestHeader HttpHeaders headers) {
+        transactionService.validateRequestWithHeaders(headers);
+
+        int userId = Integer.parseInt(headers.getFirst("User-ID"));
+        
         List<Transaction> transactionsList = transactionService.getTransactionsByUserIdAndVendorName(userId, vendorName);
         return new ResponseEntity<>(transactionsList, HttpStatus.OK);
     }
@@ -62,25 +74,31 @@ public class TransactionController {
 //    }
 
     // Mapping for creating a transaction
-    @PostMapping("/user/{userId}/createTransaction")
-    public ResponseEntity<Transaction> createTransaction(@PathVariable int userId, @RequestBody Transaction transaction, @RequestHeader HttpHeaders headers) {
-        transactionService.validateUserId(userId, headers);
-        Transaction newTransaction = transactionService.createTransaction(transaction);
+    @PostMapping
+    public ResponseEntity<Transaction> createTransaction(@RequestBody Transaction transaction, @RequestHeader HttpHeaders headers) {
+        transactionService.validateRequestWithHeaders(headers);
+
+        int userId = Integer.parseInt(headers.getFirst("User-ID"));
+        
+        Transaction newTransaction = transactionService.createTransaction(userId, transaction);
         return new ResponseEntity<>(newTransaction, HttpStatus.CREATED);
     }
 
     // Mapping for updating a transaction
-    @PutMapping("/user/{userId}/updateTransaction")
-    public ResponseEntity<Transaction> updateTransaction(@PathVariable int userId, @RequestBody Transaction transaction, @RequestHeader HttpHeaders headers) {
-        transactionService.validateUserId(userId, headers);
-        Transaction updatedTransaction = transactionService.updateTransaction(transaction);
+    @PutMapping("/{transactionId}")
+    public ResponseEntity<Transaction> updateTransaction(@PathVariable int transactionId, @RequestBody Transaction transaction, @RequestHeader HttpHeaders headers) {
+        transactionService.validateRequestWithHeaders(headers);
+
+        int userId = Integer.parseInt(headers.getFirst("User-ID"));
+        
+        Transaction updatedTransaction = transactionService.updateTransaction(transactionId, userId, transaction);
         return new ResponseEntity<>(updatedTransaction, HttpStatus.OK);
     }
 
     // Mapping for deleting a transaction with transaction Id
-    @DeleteMapping("/user/{userId}/deleteTransaction/{transactionId}")
-    public ResponseEntity<Void> deleteTransaction(@PathVariable int userId, @PathVariable int transactionId, @RequestHeader HttpHeaders headers) {
-        transactionService.validateUserId(userId, headers);
+    @DeleteMapping("/{transactionId}")
+    public ResponseEntity<Void> deleteTransaction(@PathVariable int transactionId, @RequestHeader HttpHeaders headers) {
+        transactionService.validateRequestWithHeaders(headers);
         transactionService.deleteTransaction(transactionId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/skillstorm/transactionservice/services/TransactionService.java
+++ b/src/main/java/com/skillstorm/transactionservice/services/TransactionService.java
@@ -6,7 +6,6 @@ import com.skillstorm.transactionservice.models.Transaction;
 import com.skillstorm.transactionservice.repositories.TransactionRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -19,9 +18,6 @@ import java.util.Optional;
 
 @Service
 public class TransactionService {
-
-    @Value("${GATEWAY-SECRET}")
-    private String gatewaySecret;
 
     @Autowired
     private TransactionRepository transactionRepository;
@@ -186,7 +182,6 @@ public class TransactionService {
 
     public void validateRequestWithHeaders(HttpHeaders headers) {
         String headerUserIdStr = headers.getFirst("User-ID");
-        String headerGatewaySecret = headers.getFirst("GATEWAY-SECRET");
         if (headerUserIdStr == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User ID not found in request header");
         }
@@ -195,10 +190,6 @@ public class TransactionService {
             Integer.parseInt(headerUserIdStr);
         } catch (NumberFormatException e) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid User ID format in request header");
-        }
-
-        if (headerGatewaySecret == null || !headerGatewaySecret.equals(gatewaySecret)) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid gateway secret.");
         }
     }
 }

--- a/src/main/java/com/skillstorm/transactionservice/services/TransactionService.java
+++ b/src/main/java/com/skillstorm/transactionservice/services/TransactionService.java
@@ -5,8 +5,8 @@ import com.skillstorm.transactionservice.exceptions.TransactionNotFoundException
 import com.skillstorm.transactionservice.models.Transaction;
 import com.skillstorm.transactionservice.repositories.TransactionRepository;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -20,31 +20,31 @@ import java.util.Optional;
 @Service
 public class TransactionService {
 
+    @Value("${GATEWAY-SECRET}")
+    private String gatewaySecret;
+
     @Autowired
     private TransactionRepository transactionRepository;
-
 
     // Get a list of transactions for specific user using the userId
     public List<Transaction> getTransactionsByUserId(int userId) {
         Optional<List<Transaction>> transactionList = transactionRepository.findByUserId(userId);
-        if (transactionList.isEmpty() || transactionList.get().isEmpty()){
-            throw new TransactionNotFoundException("Transactions for user ID " + userId + " not found"); 
+        if (transactionList.isEmpty() || transactionList.get().isEmpty()) {
+            throw new TransactionNotFoundException("Transactions for user ID " + userId + " not found");
         } else {
             return transactionList.get();
-        }       
+        }
     }
-
 
     /*
        Get a list of transactions from a specific user using the userId, and the list excludes the INCOME transaction category
        This method will specifically be used by the Budget Service
     */
-    public List<Transaction> getTransactionsByUserIdExcludingIncome(int userId){
+    public List<Transaction> getTransactionsByUserIdExcludingIncome(int userId) {
         Optional<List<Transaction>> transactionsList = transactionRepository.findByUserIdExcludeIncome(userId);
-        if(transactionsList.isEmpty() || transactionsList.get().isEmpty()){
+        if (transactionsList.isEmpty() || transactionsList.get().isEmpty()) {
             throw new TransactionNotFoundException("Transactions for user ID " + userId + " not found");
-        }
-        else {
+        } else {
             return transactionsList.get();
         }
     }
@@ -91,7 +91,7 @@ public class TransactionService {
     }
 
     //get a list of transactions from the current Month of a specific user using userId
-    public List<Transaction> getTransactionsFromCurrentMonth(int userId){
+    public List<Transaction> getTransactionsFromCurrentMonth(int userId) {
         LocalDate currentDate = LocalDate.now();
         int currentMonth = currentDate.getMonthValue();
         int currentYear = currentDate.getYear();
@@ -99,8 +99,6 @@ public class TransactionService {
         Optional<List<Transaction>> transactionList = transactionRepository.findTransactionFromCurrentMonth(userId, currentMonth, currentYear);
 
         return transactionList.get();
-
-
     }
 
     // Get transactions by category
@@ -114,8 +112,9 @@ public class TransactionService {
 //    }
 
     // Create a transaction
-    public Transaction createTransaction(Transaction transaction) {
+    public Transaction createTransaction(int userId, Transaction transaction) {
 
+        transaction.setUserId(userId);
 
         validateField(transaction.getAccountId() > 0, "Account ID is required");
         validateField(transaction.getUserId() > 0, "User ID is required");
@@ -124,19 +123,22 @@ public class TransactionService {
         validateField(transaction.getCategory() != null, "Category is required");
         validateField(transaction.getDate() != null, "Date is required");
 
-
         return transactionRepository.save(transaction);
     }
 
     // Update a transaction
-    public Transaction updateTransaction(Transaction transaction) {
-        Transaction existingTransaction = transactionRepository.findById(transaction.getTransactionId())
+    public Transaction updateTransaction(int transactionId, int userId, Transaction transaction) {
+        Transaction existingTransaction = transactionRepository.findById(transactionId)
                 .orElseThrow(() -> new TransactionNotFoundException("Transaction with ID " + transaction.getTransactionId() + " not found"));
 
+        if (existingTransaction.getUserId() != userId) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You are not authorized to modify this transaction.");
+        }        
+        
         if (transaction.getUserId() > 0) {
             existingTransaction.setUserId(transaction.getUserId());
         }
-        
+
         if (transaction.getAccountId() > 0) {
             existingTransaction.setAccountId(transaction.getAccountId());
         }
@@ -149,7 +151,7 @@ public class TransactionService {
             existingTransaction.setAmount(transaction.getAmount());
         }
 
-        if (transaction.getCategory() != null){
+        if (transaction.getCategory() != null) {
             existingTransaction.setCategory(transaction.getCategory());
         }
 
@@ -170,34 +172,33 @@ public class TransactionService {
         transactionRepository.deleteById(transactionId);
     }
 
-    //delete transactions associated by a specific user using userId.
-    public void deleteTransactionByUserId(int userId){
+    // delete transactions associated by a specific user using userId.
+    public void deleteTransactionByUserId(int userId) {
         transactionRepository.deleteTransactionsByUserId(userId);
     }
 
-
-    //helper method to validate Transaction fields and throw exception if invalid
+    // helper method to validate Transaction fields and throw exception if invalid
     private void validateField(boolean condition, String errorMessage) {
         if (!condition) {
             throw new InvalidTransactionException(errorMessage);
         }
     }
 
-    public void validateUserId(int pathUserId, HttpHeaders headers) {
+    public void validateRequestWithHeaders(HttpHeaders headers) {
         String headerUserIdStr = headers.getFirst("User-ID");
+        String headerGatewaySecret = headers.getFirst("GATEWAY-SECRET");
         if (headerUserIdStr == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User ID not found in request header");
         }
 
-        int headerUserId;
         try {
-            headerUserId = Integer.parseInt(headerUserIdStr);
+            Integer.parseInt(headerUserIdStr);
         } catch (NumberFormatException e) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid User ID format in request header");
         }
 
-        if (pathUserId != headerUserId) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User ID in path variable does not match User ID in request header");
+        if (headerGatewaySecret == null || !headerGatewaySecret.equals(gatewaySecret)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid gateway secret.");
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 server:
     port: 8083
+    error:
+        include-message: always
 
 spring:
     application:

--- a/src/test/java/com/skillstorm/transactionservice/controllers/TransactionBetweenServicesControllerTests.java
+++ b/src/test/java/com/skillstorm/transactionservice/controllers/TransactionBetweenServicesControllerTests.java
@@ -1,0 +1,70 @@
+package com.skillstorm.transactionservice.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.skillstorm.transactionservice.models.Transaction;
+import com.skillstorm.transactionservice.services.TransactionService;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.List;
+
+@WebMvcTest(TransactionController.class)
+public class TransactionBetweenServicesControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TransactionService transactionService;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void setup() {
+        closeable = MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(new TransactionBetweenServicesController(transactionService)).build();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void testGetTransactionsByUserIdExcludeIncome() throws Exception {
+        int userId = 1;
+        List<Transaction> transactions = Arrays.asList(new Transaction(), new Transaction());
+        when(transactionService.getTransactionsByUserIdExcludingIncome(userId)).thenReturn(transactions);
+
+        mockMvc.perform(get("/transactionsPrivate/budget/{userId}", userId))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.length()").value(transactions.size()));
+
+        verify(transactionService, times(1)).getTransactionsByUserIdExcludingIncome(userId);
+    }
+
+    @Test
+    public void testGetTransactionsByAccountId() throws Exception {
+        int accountId = 1;
+        List<Transaction> transactions = Arrays.asList(new Transaction(), new Transaction());
+        when(transactionService.getTransactionsByAccountId(accountId)).thenReturn(transactions);
+
+        mockMvc.perform(get("/transactionsPrivate/account/{accountId}", accountId))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.length()").value(transactions.size()));
+
+        verify(transactionService, times(1)).getTransactionsByAccountId(accountId);
+    }
+}

--- a/src/test/java/com/skillstorm/transactionservice/controllers/TransactionControllerTests.java
+++ b/src/test/java/com/skillstorm/transactionservice/controllers/TransactionControllerTests.java
@@ -52,7 +52,7 @@ public class TransactionControllerTests {
         List<Transaction> transactions = Arrays.asList(new Transaction(), new Transaction());
         when(transactionService.getTransactionsByUserId(userId)).thenReturn(transactions);
 
-        mockMvc.perform(get("/transactions/user/{userId}", userId))
+        mockMvc.perform(get("/transactions").header("USER-ID", "1"))
                .andExpect(status().isOk())
                .andExpect(jsonPath("$.length()").value(transactions.size()));
 
@@ -65,7 +65,7 @@ public class TransactionControllerTests {
         List<Transaction> transactions = Arrays.asList(new Transaction(), new Transaction());
         when(transactionService.getRecentFiveTransactions(userId)).thenReturn(transactions);
 
-        mockMvc.perform(get("/transactions/recentTransactions/{userId}", userId))
+        mockMvc.perform(get("/transactions/recentTransactions").header("USER-ID", "1"))
                .andExpect(status().isOk())
                .andExpect(jsonPath("$.length()").value(transactions.size()));
 
@@ -78,37 +78,11 @@ public class TransactionControllerTests {
         List<Transaction> transactions = Arrays.asList(new Transaction(), new Transaction());
         when(transactionService.getTransactionsFromCurrentMonth(userId)).thenReturn(transactions);
 
-        mockMvc.perform(get("/transactions/currentMonthTransactions/{userId}", userId))
+        mockMvc.perform(get("/transactions/currentMonthTransactions").header("USER-ID", "1"))
                .andExpect(status().isOk())
                .andExpect(jsonPath("$.length()").value(transactions.size()));
 
         verify(transactionService, times(1)).getTransactionsFromCurrentMonth(userId);
-    }
-
-    @Test
-    public void testGetTransactionsByUserIdExcludeIncome() throws Exception {
-        int userId = 1;
-        List<Transaction> transactions = Arrays.asList(new Transaction(), new Transaction());
-        when(transactionService.getTransactionsByUserIdExcludingIncome(userId)).thenReturn(transactions);
-
-        mockMvc.perform(get("/transactions/budget/{userId}", userId))
-               .andExpect(status().isOk())
-               .andExpect(jsonPath("$.length()").value(transactions.size()));
-
-        verify(transactionService, times(1)).getTransactionsByUserIdExcludingIncome(userId);
-    }
-
-    @Test
-    public void testGetTransactionsByAccountId() throws Exception {
-        int accountId = 1;
-        List<Transaction> transactions = Arrays.asList(new Transaction(), new Transaction());
-        when(transactionService.getTransactionsByAccountId(accountId)).thenReturn(transactions);
-
-        mockMvc.perform(get("/transactions/account/{accountId}", accountId))
-               .andExpect(status().isOk())
-               .andExpect(jsonPath("$.length()").value(transactions.size()));
-
-        verify(transactionService, times(1)).getTransactionsByAccountId(accountId);
     }
 
     @Test
@@ -120,9 +94,10 @@ public class TransactionControllerTests {
         transaction.setAmount(new BigDecimal("100"));
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
-        when(transactionService.createTransaction(any(Transaction.class))).thenReturn(transaction);
+        when(transactionService.createTransaction(eq(1), any(Transaction.class))).thenReturn(transaction);
 
-        mockMvc.perform(post("/transactions/createTransaction")
+        mockMvc.perform(post("/transactions")
+                .header("USER-ID", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"accountId\":1,\"userId\":1,\"vendorName\":\"Vendor\",\"amount\":100,\"category\":\"SHOPPING\",\"date\":\"" + LocalDate.now() + "\"}"))
                .andExpect(status().isCreated())
@@ -130,7 +105,7 @@ public class TransactionControllerTests {
                .andExpect(jsonPath("$.userId").value(1))
                .andExpect(jsonPath("$.vendorName").value("Vendor"));
 
-        verify(transactionService, times(1)).createTransaction(any(Transaction.class));
+        verify(transactionService, times(1)).createTransaction(eq(1), any(Transaction.class));
     }
 
     @Test
@@ -143,9 +118,10 @@ public class TransactionControllerTests {
         transaction.setAmount(new BigDecimal("100"));
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
-        when(transactionService.updateTransaction(any(Transaction.class))).thenReturn(transaction);
+        when(transactionService.updateTransaction(eq(1), eq(1), any(Transaction.class))).thenReturn(transaction);
 
-        mockMvc.perform(put("/transactions/updateTransaction")
+        mockMvc.perform(put("/transactions/1")
+                .header("USER-ID", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"transactionId\":1,\"accountId\":1,\"userId\":1,\"vendorName\":\"Vendor\",\"amount\":100,\"category\":\"SHOPPING\",\"date\":\"" + LocalDate.now() + "\"}"))
                .andExpect(status().isOk())
@@ -154,7 +130,7 @@ public class TransactionControllerTests {
                .andExpect(jsonPath("$.userId").value(1))
                .andExpect(jsonPath("$.vendorName").value("Vendor"));
 
-        verify(transactionService, times(1)).updateTransaction(any(Transaction.class));
+        verify(transactionService, times(1)).updateTransaction(eq(1), eq(1), any(Transaction.class));
     }
 
     @Test
@@ -162,7 +138,7 @@ public class TransactionControllerTests {
         int transactionId = 1;
         doNothing().when(transactionService).deleteTransaction(transactionId);
 
-        mockMvc.perform(delete("/transactions/deleteTransaction/{transactionId}", transactionId))
+        mockMvc.perform(delete("/transactions/{transactionId}", transactionId))
                .andExpect(status().isNoContent());
 
         verify(transactionService, times(1)).deleteTransaction(transactionId);

--- a/src/test/java/com/skillstorm/transactionservice/services/TransactionServiceIntegrationTests.java
+++ b/src/test/java/com/skillstorm/transactionservice/services/TransactionServiceIntegrationTests.java
@@ -145,7 +145,7 @@ public class TransactionServiceIntegrationTests {
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
 
-        Transaction result = transactionService.createTransaction(transaction);
+        Transaction result = transactionService.createTransaction(1, transaction);
 
         assertThat(result).isNotNull();
         assertThat(result.getTransactionId()).isNotNull();
@@ -161,7 +161,7 @@ public class TransactionServiceIntegrationTests {
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
 
-        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(transaction));
+        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(1, transaction));
     }
 
     @Test
@@ -174,7 +174,7 @@ public class TransactionServiceIntegrationTests {
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
 
-        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(transaction));
+        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(0, transaction));
     }
 
     @Test
@@ -187,7 +187,7 @@ public class TransactionServiceIntegrationTests {
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
 
-        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(transaction));
+        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(1, transaction));
     }
 
     @Test
@@ -202,7 +202,7 @@ public class TransactionServiceIntegrationTests {
         transaction = transactionRepository.save(transaction);
 
         transaction.setVendorName("Updated Vendor");
-        Transaction result = transactionService.updateTransaction(transaction);
+        Transaction result = transactionService.updateTransaction(1, 1, transaction);
 
         assertThat(result.getVendorName()).isEqualTo("Updated Vendor");
     }
@@ -212,7 +212,7 @@ public class TransactionServiceIntegrationTests {
         Transaction transaction = new Transaction();
         transaction.setTransactionId(1);
 
-        assertThrows(TransactionNotFoundException.class, () -> transactionService.updateTransaction(transaction));
+        assertThrows(TransactionNotFoundException.class, () -> transactionService.updateTransaction(4, 1, transaction));
     }
 
     @Test

--- a/src/test/java/com/skillstorm/transactionservice/services/TransactionServiceTests.java
+++ b/src/test/java/com/skillstorm/transactionservice/services/TransactionServiceTests.java
@@ -146,7 +146,7 @@ public class TransactionServiceTests {
         transaction.setDate(LocalDate.now());
         when(transactionRepository.save(transaction)).thenReturn(transaction);
 
-        Transaction result = transactionService.createTransaction(transaction);
+        Transaction result = transactionService.createTransaction(1, transaction);
 
         assertEquals(transaction, result);
         verify(transactionRepository, times(1)).save(transaction);
@@ -162,7 +162,7 @@ public class TransactionServiceTests {
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
 
-        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(transaction));
+        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(1, transaction));
     }
 
     @Test
@@ -175,7 +175,7 @@ public class TransactionServiceTests {
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
 
-        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(transaction));
+        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(0, transaction));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class TransactionServiceTests {
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
 
-        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(transaction));
+        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(1, transaction));
     }
 
     @Test
@@ -201,7 +201,7 @@ public class TransactionServiceTests {
         transaction.setCategory(TransactionCategory.SHOPPING);
         transaction.setDate(LocalDate.now());
 
-        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(transaction));
+        assertThrows(InvalidTransactionException.class, () -> transactionService.createTransaction(1, transaction));
     }
 
     @Test
@@ -217,7 +217,7 @@ public class TransactionServiceTests {
         when(transactionRepository.findById(transaction.getTransactionId())).thenReturn(Optional.of(transaction));
         when(transactionRepository.save(transaction)).thenReturn(transaction);
 
-        Transaction result = transactionService.updateTransaction(transaction);
+        Transaction result = transactionService.updateTransaction(1, 1, transaction);
 
         assertEquals(transaction, result);
         verify(transactionRepository, times(1)).findById(transaction.getTransactionId());
@@ -230,7 +230,7 @@ public class TransactionServiceTests {
         transaction.setTransactionId(1);
         when(transactionRepository.findById(transaction.getTransactionId())).thenReturn(Optional.empty());
 
-        assertThrows(TransactionNotFoundException.class, () -> transactionService.updateTransaction(transaction));
+        assertThrows(TransactionNotFoundException.class, () -> transactionService.updateTransaction(1, 1, transaction));
     }
 
     @Test


### PR DESCRIPTION
## Bugs
I couldn't get Integration Tests to run, It gives me an ApplicationContextError whenever I try to run unfortunately.

## TRANSACTIONS CHANGES

* **ADDED** server.error.include-message=always to `application.yml` for improved error messages.

* **ADDED** tests for private controller between services, removed previous endpoints from original controller tests.

* **MODIFIED** `service.updateTransaction()` to accept an additional transactionId argument, taken from the PathVariable of the PUT mapping to follow RESTful conventions, and an additional userId argument, taken from the `USER-ID` header to ensure the correct user is modifying the transaction.

* **MODIFIED** `service.createTransaction()` to accept an additional userId argument, taken from the `USER-ID` header.

* **REFACTORED** `service.validateUserId()` into `service.validateRequestWithHeaders()` which verifies the `USER-ID` header.

* **REMOVED** userId path variables from controller endpoints, uses the `USER-ID` header now.

* **REMOVED** CrossOrigin annotation from TransactionController since we are using the gateway CORS now.


## TRANSACTIONS ENDPOINTS

`GET /transactions/user/{userId}` => `GET /transactions`

`GET /transactions/recentTransactions/{userId}` => `GET /transactions/recentTransactions`

`GET /transactions/currentMonthTransactions/{userId}` => `GET /transactions/currentMonthTransactions`

`GET /transactions/user/{userId}/vendor/{vendorName}` => `GET /transactions/vendor/{vendorName}` 

`POST /transactions/user/{userId}/createTransaction` => `POST /transactions`

`PUT /transactions/user/{userId}/updateTransactions` => `PUT /transactions/{transactionId}`

`DELETE /transactions/user/{userId}/deleteTransaction/{transactionId}` => `DELETE /transactions/{transactionId}`